### PR TITLE
feat: RealTime에서 quotient 계산하는 로직 수정

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -150,7 +150,8 @@ const Home: NextPage = () => {
       );
       getRealTimeDatas(target);
 
-      const quotient = Math.ceil(getData.totCnt / 1000);
+      const quotient =
+        getData.data.length === 0 ? 1 : Math.ceil(getData.totCnt / 1000);
       if (pageNo === "1") {
         if (quotient > 1) {
           for (let i = 2; i <= quotient; i++) {


### PR DESCRIPTION

### 문제 원인
```tsx
const quotient =  Math.ceil(getData.totCnt / 1000);
```

quotient 변수는 전체 데이터를 1000으로 나누어서 페이지 수를 의미한다. 
나머지가 있을 경우 무조건 올림처리한다.

이때 만약 데이터가 없을 경우 `getData.totCnt` 값은 0이된다. 따라서 1000으로 나누어도 값이 0이되고 있었고

페이지를 비교할 때 요청한 페이지 "1"과 "0"이 비교 되고 있었음.

### 해결 방안

```tsx
const quotient = getData.data.length === 0 ? 1 : Math.ceil(getData.totCnt / 1000);
```

먼저 데이터의 길이를 확인하고 0일 경우 1로 할당한다. 

close #7 